### PR TITLE
label/deutschePost: add support for the first label in a "Briefmarken Bogen"

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,9 @@
                                         <option value="dp-briefmarke-adresse">
                                             briefmarke_adresse | 62x80mm
                                         </option>
+                                        <option value="dp-briefmarke-bogen">
+                                            briefmarke_bogen | 62x40mm
+                                        </option>
                                     </optgroup>
                                     <optgroup label="hermes">
                                         <option value="hermes-privat-v102">

--- a/src/js/labels.js
+++ b/src/js/labels.js
@@ -8,6 +8,7 @@ export default function (labelType) {
         case 'dp-briefmarke': return dpBriefmarke;
         case 'dp-briefmarke-short': return dpBriefmarkeShort
         case 'dp-briefmarke-adresse': return dpBriefmarkeAdresse;
+        case 'dp-briefmarke-bogen':  return dpBriefmarkeBogen;
         case 'hermes-privat-v102': return hermesPrivatV102;
         case 'hermes-privat-v111': return hermesPrivatV111;
         case 'hermes-vinted-qr': return hermesVintedQR;
@@ -333,6 +334,23 @@ const dpBriefmarkeAdresse = {
         ctx.drawImage(image,
             64, 18, 874, 696,
             0, 0, 874, 696);
+    }
+};
+
+const dpBriefmarkeBogen = {
+    file: {
+        type: 'pdf',
+        page: 1,
+        rotation: 0
+    },
+    scale: 4.1666,
+    width: 402,    // 34mm (=> 40mm)
+    crop(outputCanvas, ctx, image) {
+        ctx.rotate(-Math.PI / 2)
+        ctx.drawImage(image,
+            45, 167, 765, 402,
+            -750, 0, 765, 402);
+        ctx.rotate(Math.PI / 2)
     }
 };
 


### PR DESCRIPTION
The Deutsche Post now sells online Briefmarken on a sheet even if only a single one was ordered.

Noteworhty: I comparison to other Briefmarken in `label.js` the source PDF is *not* rotated before the image is cropped but the cropped image is rendered after rotation on canvas level

<img width="735" height="1012" alt="BriefmarkenBogen" src="https://github.com/user-attachments/assets/008919b5-41e0-4ad0-bc6a-17e0ef3e5178" />

If you have some guidance on how to censor it safely on PDF level I will happily upload it to the sample PDFs