### PR TITLE
Add support for the changed Bahntransport Logo

### DIFF
--- a/src/js/labels.js
+++ b/src/js/labels.js
@@ -29,6 +29,16 @@ export default function (labelType) {
     };
 }
 
+function isCanvasEmpty(ctx, x, y, width, height) {
+    const imgData = ctx.getImageData(x, y, width, height);
+    for (let i = 0; i < imgData.data.length; i += 4) {
+        if (imgData.data[i]!=0xFF || imgData.data[i+1]!=0xFF || imgData.data[i+2]!=0xFF) {
+            return false; // Found a non-transparent pixel
+        }
+    }
+    return true; // All pixels are transparent
+}
+
 const template = {
     file: {
         type: 'pdf',

--- a/src/js/labels.js
+++ b/src/js/labels.js
@@ -81,6 +81,13 @@ const dhlPrivat = {
             2802, 679, 234, 154,
             666, 465, 152, 100);
 
+        // We didnt render any bahntransport label yet, lets try the second common position
+        if (isCanvasEmpty(ctx, 666, 465, 152, 100)) {
+            ctx.drawImage(image,   // Bahntransport v2
+                2763, 540, 250, 154,
+                666, 465, 152, 100);
+        }
+
         ctx.drawImage(image,   // Sendungsdaten
             1964, 933, 1124, 152,
             0, 576, 890, 120);


### PR DESCRIPTION
The bahntransport is now exported as an icon below the security code. To ensure we dont render over any previously rendered images we add a small helper to check if the target area is available to render into

<img width="542" height="271" alt="image" src="https://github.com/user-attachments/assets/af9b5265-ecfd-4d5c-ba86-a72256144292" />
